### PR TITLE
Improve Stuttering on MKS LTS v1.1 Board

### DIFF
--- a/Firmware/Grbl_Esp32/src/Grbl.cpp
+++ b/Firmware/Grbl_Esp32/src/Grbl.cpp
@@ -128,6 +128,7 @@ void _mc_task_init(void) {
 #if defined(LCD_EN)
     disp_task_init();
 #endif
+    gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
 }
 
 

--- a/Firmware/Grbl_Esp32/src/Grbl.cpp
+++ b/Firmware/Grbl_Esp32/src/Grbl.cpp
@@ -32,10 +32,11 @@ void grbl_init() {
     disableCore0WDT();
     disableCore1WDT();
 
+#ifdef LCD_EN
     pinMode(LCD_EN, OUTPUT);
-    
     LCD_BLK_OFF;
-    
+#endif
+
 #ifdef USE_I2S_OUT
     i2s_out_init();  // The I2S out must be initialized before it can access the expanded GPIO port
 #endif
@@ -120,9 +121,13 @@ void _mc_task_init(void) {
     mks_grbl_parg_init();
     ts35_beep_init();
     bsp_led_init();
+#if defined(LCD_EN)
     tft_TS35_init();
+#endif
     test_cfg_find_init();
+#if defined(LCD_EN)
     disp_task_init();
+#endif
 }
 
 

--- a/Firmware/Grbl_Esp32/src/I2SOut.cpp
+++ b/Firmware/Grbl_Esp32/src/I2SOut.cpp
@@ -51,13 +51,13 @@
 #include "Serial.h"
 #include "Report.h"
 
-#include <FreeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <driver/periph_ctrl.h>
 #include <rom/lldesc.h>
 #include <soc/i2s_struct.h>
 #include <freertos/queue.h>
 
-#include <stdatomic.h>
+#include <atomic>
 
 #include "Pins.h"
 #include "I2SOut.h"
@@ -99,7 +99,7 @@ static intr_handle_t i2s_out_isr_handle;
 #endif
 
 // output value
-static atomic_uint_least32_t i2s_out_port_data = ATOMIC_VAR_INIT(0);
+static std::atomic<uint32_t> i2s_out_port_data = ATOMIC_VAR_INIT(0);
 
 // inner lock
 static portMUX_TYPE i2s_out_spinlock = portMUX_INITIALIZER_UNLOCKED;

--- a/Firmware/Grbl_Esp32/src/Machine.h
+++ b/Firmware/Grbl_Esp32/src/Machine.h
@@ -7,6 +7,8 @@
 
 #ifdef MACHINE_TYPE_DEFAULT
     #include "Machines/i2s_out_xyz_mks_dlc32.h"
+#elif defined(MACHINE_TYPE_LTS)
+    #include "Machines/i2s_out_xy_mks_lts.h"
 #else
     #include "Machines/i2s_out_corexy_mks_dlc32.h"
 #endif

--- a/Firmware/Grbl_Esp32/src/Machines/i2s_out_xy_mks_lts.h
+++ b/Firmware/Grbl_Esp32/src/Machines/i2s_out_xy_mks_lts.h
@@ -1,0 +1,152 @@
+#pragma once
+
+/*
+    i2s_out_xy_mks_lts.h
+    Part of Grbl_ESP32
+    Pin assignments for the MKS LTS v1.1 Laser Board
+    2018    - Bart Dring
+    2020    - Mitch Bradley
+    2020    - Michiyasu Odaki
+    2021    - @Makerbase
+    2023    - Richard Taylor
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define MACHINE_NAME            "MKS LTS"
+#define BOARD_NAME              "MKS LTS v1.1 Laser"
+
+#define FW_NAME                 "V2.1(8M.LTS.20230805)"
+
+
+#ifdef N_AXIS
+    #undef N_AXIS
+#endif
+#define N_AXIS 3
+
+#define HTTP_UPLOAD_BUFLEN 1024*10
+
+#define ENABLE_SOFTWARE_DEBOUNCE
+
+#undef ENABLE_LCD
+
+// I2S (steppers & other output-only pins)
+#define USE_I2S_OUT
+#define USE_I2S_STEPS
+#define DEFAULT_STEPPER ST_I2S_STATIC
+
+// I2S pins set
+#define I2S_OUT_BCK                 GPIO_NUM_16
+#define I2S_OUT_WS                  GPIO_NUM_17
+#define I2S_OUT_DATA                GPIO_NUM_21
+
+// X I2S pin set
+#define X_DISABLE_PIN               I2SO(0)
+#define X_DIRECTION_PIN             I2SO(2)
+#define X_STEP_PIN                  I2SO(1)
+
+// Y I2S pin set
+#define Y_DISABLE_PIN               I2SO(0)
+#define Y_DIRECTION_PIN             I2SO(6)
+#define Y_STEP_PIN                  I2SO(5)
+
+// Laser pin set
+#define SPINDLE_TYPE                SpindleType::LASER
+#define SPINDLE_OUTPUT_PIN          GPIO_NUM_22
+#define LASER_OUTPUT_PIN            GPIO_NUM_22
+
+#define X_LIMIT_PIN                 GPIO_NUM_36
+#define Y_LIMIT_PIN                 GPIO_NUM_35
+
+#if defined(ENABLE_LCD)
+#define LCD_SCK				        GPIO_NUM_18
+#define LCD_MISO				    GPIO_NUM_19
+#define LCD_MOSI				    GPIO_NUM_23
+#define LCD_RS					    GPIO_NUM_33
+#define LCD_EN					    GPIO_NUM_5
+#define LCD_RST					    GPIO_NUM_27
+#define LCD_CS					    GPIO_NUM_25
+#define TOUCH_CS				    GPIO_NUM_26
+#define BEEPER					    I2SO(7)
+#endif
+
+#define IIC_SCL                     GPIO_NUM_4
+#define IIC_SDA                     GPIO_NUM_0
+
+#define COOLANT_FLOOD_PIN           IIC_SCL
+
+//sd card spi
+#define GRBL_SPI_SCK 			    GPIO_NUM_14
+#define GRBL_SPI_MISO 			    GPIO_NUM_12
+#define GRBL_SPI_MOSI 			    GPIO_NUM_13
+#define GRBL_SPI_SS 			    GPIO_NUM_15
+#define SDCARD_DET_PIN 			    GPIO_NUM_39
+#define GRBL_SPI_FREQ 			    40000000
+
+// === Default settings
+// #define DEFAULT_STEP_PULSE_MICROSECONDS I2S_OUT_USEC_PER_PULSE
+#define DEFAULT_STEP_PULSE_MICROSECONDS     10
+
+#define DEFAULT_STEPPER_IDLE_LOCK_TIME      25
+
+#define DEFAULT_STEPPING_INVERT_MASK    	0 // uint8_t
+#define DEFAULT_DIRECTION_INVERT_MASK   	2 // uint8_t
+#define DEFAULT_INVERT_ST_ENABLE        	0 // boolean
+#define DEFAULT_INVERT_LIMIT_PINS       	1 // boolean
+#define DEFAULT_INVERT_PROBE_PIN        	1 // boolean
+
+#define DEFAULT_STATUS_REPORT_MASK 			1
+
+#define DEFAULT_JUNCTION_DEVIATION  		0.01        // mm
+#define DEFAULT_ARC_TOLERANCE       		0.002       // mm
+#define DEFAULT_REPORT_INCHES       		0           // false
+
+#define DEFAULT_SOFT_LIMIT_ENABLE 			0           // false
+#define DEFAULT_HARD_LIMIT_ENABLE 			0           // false
+
+#define DEFAULT_HOMING_CYCLE_0              (bit(X_AXIS) | bit(Y_AXIS))
+#define DEFAULT_HOMING_CYCLE_1              0           // (bit(Z_AXIS))        /* If you want star Z axis, select (bit(Z_AXIS)) */
+#define DEFAULT_HOMING_ENABLE           	0           // false
+#define DEFAULT_HOMING_DIR_MASK         	1           // move positive dir Z,negative X,Y
+#define DEFAULT_HOMING_FEED_RATE        	300.0       // mm/min
+#define DEFAULT_HOMING_SEEK_RATE        	1000.0      // mm/min
+#define DEFAULT_HOMING_DEBOUNCE_DELAY   	250         // msec (0-65k)
+#define DEFAULT_HOMING_PULLOFF          	1.0         // mm
+
+#define DEFAULT_SPINDLE_RPM_MAX 10000.0 // can be change to your spindle max
+#define DEFAULT_SPINDLE_RPM_MIN 0.0 // rpm
+
+#define DEFAULT_LASER_MODE 1 // true
+
+#define DEFAULT_X_STEPS_PER_MM 80.0
+#define DEFAULT_Y_STEPS_PER_MM 80.0
+#define DEFAULT_Z_STEPS_PER_MM 80.0
+
+#define DEFAULT_X_MAX_RATE 6000.0 // mm/s
+#define DEFAULT_Y_MAX_RATE 6000.0 // mm/s
+#define DEFAULT_Z_MAX_RATE 6000.0 // mm/s
+
+#define DEFAULT_X_ACCELERATION 500.0 // mm/sec^2
+#define DEFAULT_Y_ACCELERATION 500.0 // mm/sec^2
+#define DEFAULT_Z_ACCELERATION 500.0 // mm/sec^2
+
+#define DEFAULT_X_MAX_TRAVEL 450.0 // mm NOTE: Must be a positive value.
+#define DEFAULT_Y_MAX_TRAVEL 450.0 // mm NOTE: Must be a positive value.
+#define DEFAULT_Z_MAX_TRAVEL 50.0 // mm NOTE: Must be a positive value.
+
+#define DEFAULT_SPINDLE_FREQ        1920// 8000.0   // 1KHz
+#define DEFAULT_LASER_FULL_POWER    1000
+#define DEFAULT_SPINDLE_MAX_VALUE   1000
+#define DEFAULT_SPINDLE_MIN_VALUE   0
+
+
+#define DEFAULT_BEEP_STATUS                 1
+#define DEFAULT_LANGUAGE_STATUS             1       // default simple English

--- a/Firmware/Grbl_Esp32/src/Serial.cpp
+++ b/Firmware/Grbl_Esp32/src/Serial.cpp
@@ -184,9 +184,9 @@ void clientCheckTask(void* pvParameters) {
 #if defined(ENABLE_SD_CARD)
                 if (get_sd_state(false) < SDState::Busy) {
 #endif  //ENABLE_SD_CARD
-                    vTaskEnterCritical(&myMutex);
+                    vPortEnterCritical(&myMutex);
                     client_buffer[client].write(data);
-                    vTaskExitCritical(&myMutex);
+                    vPortExitCritical(&myMutex);
 #if defined(ENABLE_SD_CARD)
                 } else {
                     if (data == '\r' || data == '\n') {
@@ -229,9 +229,9 @@ void client_reset_read_buffer(uint8_t client) {
 
 // Fetches the first byte in the client read buffer. Called by protocol loop.
 int client_read(uint8_t client) {
-    vTaskEnterCritical(&myMutex);
+    vPortEnterCritical(&myMutex);
     int data = client_buffer[client].read();
-    vTaskExitCritical(&myMutex);
+    vPortExitCritical(&myMutex);
     return data;
 }
 

--- a/Firmware/Grbl_Esp32/src/Stepper.cpp
+++ b/Firmware/Grbl_Esp32/src/Stepper.cpp
@@ -958,7 +958,7 @@ void IRAM_ATTR Stepper_Timer_Init() {
     config.counter_en  = TIMER_PAUSE;
     config.alarm_en    = TIMER_ALARM_EN;
     config.intr_type   = TIMER_INTR_LEVEL;
-    config.auto_reload = true;
+    config.auto_reload = TIMER_AUTORELOAD_EN;
     timer_init(STEP_TIMER_GROUP, STEP_TIMER_INDEX, &config);
     timer_set_counter_value(STEP_TIMER_GROUP, STEP_TIMER_INDEX, 0x00000000ULL);
     timer_enable_intr(STEP_TIMER_GROUP, STEP_TIMER_INDEX);

--- a/Firmware/Grbl_Esp32/src/WebUI/WebSettings.cpp
+++ b/Firmware/Grbl_Esp32/src/WebUI/WebSettings.cpp
@@ -427,8 +427,8 @@ namespace WebUI {
         webPrintln("CPU Temperature: ", String(temperatureRead(), 1) + "C");
         webPrintln("Free memory: ", ESPResponseStream::formatBytes(ESP.getFreeHeap()));
         webPrintln("SDK: ", ESP.getSdkVersion());
-        webPrintln("Board Version: ", "DLC32 V003"); // mks fix
-        webPrintln("Firmware: ", "DLC32 V1.10C"); // mks fix
+        webPrintln("Board Version: ", BOARD_NAME);
+        webPrintln("Firmware: ", FW_NAME);
         webPrintln("Flash Size: ", ESPResponseStream::formatBytes(ESP.getFlashChipSize()));
 
         // Round baudRate to nearest 100 because ESP32 can say e.g. 115201

--- a/Firmware/Grbl_Esp32/src/mks/MKS_FREERTOS_TASK.cpp
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_FREERTOS_TASK.cpp
@@ -13,6 +13,8 @@ TaskHandle_t frame_task_tcb = NULL;
 
 #define USE_DelayUntil
 
+#if defined(LCD_EN)
+
 static void mks_page_data_updata(void);
 
 IRAM_ATTR void lvgl_disp_task(void *parg) { 
@@ -208,6 +210,7 @@ IRAM_ATTR void disp_task_init(void) {
                                                 // core
     );
 }
+#endif // defined(LCD_EN)
 
 /*-------------------------------------------------------------------------------------------------*/
 

--- a/Firmware/Grbl_Esp32/src/mks/MKS_FREERTOS_TASK.h
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_FREERTOS_TASK.h
@@ -1,7 +1,7 @@
 #ifndef __MKS_FREERTOS_TASK_
 #define __MKS_FREERTOS_TASK_
 
-#include "FreeRTOS.h"
+#include "freertos/FreeRTOS.h"
 #include "MKS_LVGL.h"
 #include "MKS_draw_ready.h"
 

--- a/Firmware/Grbl_Esp32/src/mks/MKS_LVGL.cpp
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_LVGL.cpp
@@ -9,6 +9,8 @@ static lv_disp_buf_t    disp_buf;
 static lv_color_t       bmp_public_buf[LV_BUF_SIZE];
 // static lv_color_t       bmp_private_buf1[LV_BUF_SIZE]; 
 
+#if defined(LCD_EN)
+
 /* Function */
 void my_disp_flush(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * color_p);
 bool my_indev_touch(struct _lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
@@ -92,6 +94,7 @@ bool my_indev_touch(struct _lv_indev_drv_t * indev_drv, lv_indev_data_t * data) 
     }
     return false;
 }   
+#endif // defined(LCD_EN)
 
 #if USE_LV_LOG != 0
 /* Serial debugging */

--- a/Firmware/Grbl_Esp32/src/mks/MKS_TS35.cpp
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_TS35.cpp
@@ -1,5 +1,6 @@
 #include "MKS_TS35.h"
 
+#if defined(LCD_EN)
 TFT_eSPI tft = TFT_eSPI(); 
 
 void tft_LCD_Fill() {
@@ -13,20 +14,26 @@ void tft_TS35_init() {
     tft.initDMA();
     delay_ms(100);
 }   
+#endif
 
 void ts35_beep_init() { 
+#if defined(BEEPER)
     pinMode(BEEPER, OUTPUT);
     digitalWrite(BEEPER, LOW);
+#endif
 }
 
 void ts35_beep_on(void) {
+#if defined(BEEPER)
     if(beep_status->get()) digitalWrite(BEEPER, HIGH);
+#endif
 }
 
 void ts35_beep_off(void) {
+#if defined(BEEPER)
     digitalWrite(BEEPER, LOW);
+#endif
 }
-
 
 #define LED_RESOLUTION      10
 #define LED_CHANNEL         14

--- a/Firmware/Grbl_Esp32/src/mks/MKS_TS35.h
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_TS35.h
@@ -34,6 +34,7 @@
 #define BEEP_OFF           
 #endif
 
+#if defined (LCD_EN)
 #ifdef USE_VERSION_003
 #define LCD_BLK_ON          digitalWrite(LCD_EN, HIGH)
 #define LCD_BLK_OFF         digitalWrite(LCD_EN, LOW)
@@ -47,6 +48,8 @@ extern TFT_eSPI tft;
 
 void tft_TS35_init();
 void tft_TS35_SPI_begin(void);
+#endif
+
 void ts35_beep_init();
 void ts35_beep_on(void);
 void ts35_beep_off(void);

--- a/Firmware/ini/mks_dlc32.ini
+++ b/Firmware/ini/mks_dlc32.ini
@@ -5,7 +5,7 @@
 # - Flash Mode: DOUT        - for ESP32 Flash mode
 ################################################################
 [esp32_common]
-platform = espressif32@3.2.0
+platform = espressif32@6.3.2
 framework = arduino
 board = esp32dev
 board_build.f_cpu = 160000000L

--- a/Firmware/ini/mks_dlc32.ini
+++ b/Firmware/ini/mks_dlc32.ini
@@ -5,7 +5,7 @@
 # - Flash Mode: DOUT        - for ESP32 Flash mode
 ################################################################
 [esp32_common]
-platform = espressif32@3.2.0 
+platform = espressif32@3.2.0
 framework = arduino
 board = esp32dev
 board_build.f_cpu = 160000000L
@@ -42,4 +42,16 @@ upload_speed = 921600
 build_flags = ${esp32_common.build_flags}
 			-D MACHINE_TYPE_COREXY
 lib_deps = 
+    TMCStepper@>=0.7.0,<1.0.0
+
+; For MKS LTS
+[env:mks_lts_v2_1]
+platform = ${esp32_common.platform}
+extends = esp32_common
+board_build.partitions = huge_app.csv
+upload_port = COM8
+upload_speed = 921600
+build_flags = ${esp32_common.build_flags}
+			-D MACHINE_TYPE_LTS
+lib_deps =
     TMCStepper@>=0.7.0,<1.0.0

--- a/Firmware/libraries/arduinoWebSockets/src/WebSockets.cpp
+++ b/Firmware/libraries/arduinoWebSockets/src/WebSockets.cpp
@@ -39,7 +39,7 @@ extern "C" {
 #ifdef ESP8266
 #include <Hash.h>
 #elif defined(ESP32)
-#include <hwcrypto/sha.h>
+#include <rom/sha.h>
 #else
 
 extern "C" {
@@ -489,7 +489,10 @@ String WebSockets::acceptKey(String & clientKey) {
     sha1(clientKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", &sha1HashBin[0]);
 #elif defined(ESP32)
     String data = clientKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-    esp_sha(SHA1, (unsigned char*)data.c_str(), data.length(), &sha1HashBin[0]);
+    SHA_CTX ctx;
+    ets_sha_init(&ctx);
+    ets_sha_update(&ctx, SHA1, (const unsigned char*)clientKey.c_str(), clientKey.length());
+    ets_sha_finish(&ctx, SHA1, &sha1HashBin[0]);
 #else
     clientKey += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
     SHA1_CTX ctx;


### PR DESCRIPTION
Please find a patch that does the following:
 - Add the MKS LTS v1.1 board as found in the TwoTrees TTS-55
 - Enable SD support
 - Disable LCD when pins not defined (helps reduce stutter)
 - Update code so that it works with the latest platform-espressif32 tag (6.3.2 at the time of writing)

Known issues:
 - Unable to test on a DLC32 board! 
 - Although improved, telnet still barfs with a pbuf_free crash. (This was my reason for updating the platform)

Without the changes, I can only smoothly draw a 20mm circle at 40mm/s. With this change, it is smooth to 100mm/s.
My motivation is to improve my image engraving experience from LightBurn, ideally over TCP!