### PR TITLE
Add Long Press Functionality for Axis Movement Controls

### DIFF
--- a/Firmware/Grbl_Esp32/src/mks/MKS_draw_move.h
+++ b/Firmware/Grbl_Esp32/src/mks/MKS_draw_move.h
@@ -103,6 +103,11 @@ typedef struct{
     MKS_HOMING_T soft_homing_status;        // 软限位回零配置
     uint8_t      limit_dis_delay_count=0;     // 类似于消抖
     
+    // Long press state tracking
+    bool         is_long_press_active;        // Track if we're in long press mode
+    char         long_press_axis;             // Which axis is being long pressed ('X', 'Y', or 'Z')
+    uint8_t      long_press_direction;        // Direction (0 or 1)
+    
 }MKS_MOVE_CTRL_T;
 
 extern MKS_MOVE_PAGE move_page;
@@ -141,4 +146,6 @@ void set_xy_home(void);
 void set_z_home(void);
 void move_pos_update(void);
 void probe_check();
+void start_continuous_movement(char axis, uint8_t dir);
+void stop_continuous_movement(void);
 #endif

--- a/Firmware/libraries/lvgl/lv_conf.h
+++ b/Firmware/libraries/lvgl/lv_conf.h
@@ -116,7 +116,7 @@ typedef int16_t lv_coord_t;
 
 /* Long press time in milliseconds.
  * Time to send `LV_EVENT_LONG_PRESSSED`) */
-#define LV_INDEV_DEF_LONG_PRESS_TIME      400
+#define LV_INDEV_DEF_LONG_PRESS_TIME      300
 
 /* Repeated trigger period in long press [ms]
  * Time between `LV_EVENT_LONG_PRESSED_REPEAT */


### PR DESCRIPTION

Description
This pull request adds enhanced control to the axis movement arrows (X, Y, Z) in the interface.

Current behavior:

When an arrow button is pressed and released, the corresponding motor moves a predefined distance at a predefined speed.

New behavior:

If the arrow button is pressed and released within 300 ms, it performs the same predefined movement as before.
If the button is pressed and held longer than 300 ms, this triggers a "long press" action. During a long press:
The motor moves continuously at a predefined speed (low, mid, or high) while the button is held down.
As soon as the button is released, movement stops immediately.
This change provides users with both precise incremental movement and convenient continuous movement for axis control.